### PR TITLE
fix: cannot compile library without necessary revision specification 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,18 +16,23 @@ futures-channel = '0.3'
 
 [dependencies.glib]
 git = 'https://github.com/gtk-rs/gtk-rs-core'
+rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295'
 
 [dependencies.glib-sys]
 git = 'https://github.com/gtk-rs/gtk-rs-core'
+rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295'
 
 [dependencies.gio]
 git = 'https://github.com/gtk-rs/gtk-rs-core'
+rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295'
 
 [dependencies.gio-sys]
 git = 'https://github.com/gtk-rs/gtk-rs-core'
+rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295'
 
 [dependencies.gobject-sys]
 git = 'https://github.com/gtk-rs/gtk-rs-core'
+rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295'
 
 [dependencies.ffi]
 package = 'nm-sys'
@@ -39,13 +44,6 @@ anyhow = '1.0'
 [dev-dependencies.clap]
 version = '3'
 features = ['derive']
-
-[patch."https://github.com/gtk-rs/gtk-rs-core"]
-glib = { git = "https://github.com/gtk-rs//gtk-rs-core.git", rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295' }
-glib-sys = { git = "https://github.com/gtk-rs//gtk-rs-core.git", rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295' }
-gio = { git = "https://github.com/gtk-rs//gtk-rs-core.git", rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295' }
-gio-sys = { git = "https://github.com/gtk-rs//gtk-rs-core.git", rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295' }
-gobject-sys = { git = "https://github.com/gtk-rs//gtk-rs-core.git", rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295' }
 
 [features]
 v1_2 = ['ffi/v1_2']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,13 @@ anyhow = '1.0'
 version = '3'
 features = ['derive']
 
+[patch."https://github.com/gtk-rs/gtk-rs-core"]
+glib = { git = "https://github.com/gtk-rs//gtk-rs-core.git", rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295' }
+glib-sys = { git = "https://github.com/gtk-rs//gtk-rs-core.git", rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295' }
+gio = { git = "https://github.com/gtk-rs//gtk-rs-core.git", rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295' }
+gio-sys = { git = "https://github.com/gtk-rs//gtk-rs-core.git", rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295' }
+gobject-sys = { git = "https://github.com/gtk-rs//gtk-rs-core.git", rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295' }
+
 [features]
 v1_2 = ['ffi/v1_2']
 v1_4 = ['ffi/v1_4', 'v1_2']

--- a/nm-sys/Cargo.toml
+++ b/nm-sys/Cargo.toml
@@ -21,14 +21,17 @@ libc = '0.2'
 [dependencies.glib]
 package = 'glib-sys'
 git = 'https://github.com/gtk-rs/gtk-rs-core'
+rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295'
 
 [dependencies.gio]
 package = 'gio-sys'
 git = 'https://github.com/gtk-rs/gtk-rs-core'
+rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295'
 
 [dependencies.gobject]
 package = 'gobject-sys'
 git = 'https://github.com/gtk-rs/gtk-rs-core'
+rev = 'cab7e1c549675cbe98af461ebbcc04c33c8f1295'
 
 [build-dependencies]
 system-deps = '1.3'


### PR DESCRIPTION
I'm using this library for my own personal project and recently I've been unable to compile due to build-errors related to the dependency specifications for this library.

gtk-rs has gone through a LOT of updates since the last commit for the repo which includes a plethora of breaking changes. modifying the relevant `Cargo.toml` specifications to include a specific commit revision avoids these issues.